### PR TITLE
Checked box to allow only application extension safe APIs

### DIFF
--- a/FFDataWrapper.xcodeproj/project.pbxproj
+++ b/FFDataWrapper.xcodeproj/project.pbxproj
@@ -374,6 +374,7 @@
 		572AF0B620371C230094DA85 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -398,6 +399,7 @@
 		572AF0B720371C230094DA85 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -541,6 +543,7 @@
 		A5063F981F73B29500CA4109 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
@@ -564,6 +567,7 @@
 		A5063F991F73B29500CA4109 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;


### PR DESCRIPTION
This is necessary to avoid linking warnings like:

ld: warning: linking against a dylib which is not safe for use in application extensions: 

FFDataWrapper.framework/FFDataWrapper

This framework should be usable within application extensions.